### PR TITLE
Optimize Spring Modulith dependencies.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -44,26 +44,14 @@
 			<artifactId>spring-ai-openai-spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.modulith</groupId>
-			<artifactId>spring-modulith-starter-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.modulith</groupId>
-			<artifactId>spring-modulith-events-api</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-	 	<dependency>
-			<groupId>org.springframework.modulith</groupId>
-			<artifactId>spring-modulith-actuator</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+		<!-- Both actuators and observability -->
 		<dependency>
 			<groupId>org.springframework.modulith</groupId>
-			<artifactId>spring-modulith-observability</artifactId>
+			<artifactId>spring-modulith-starter-insight</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Avoid explicit declaration of Core starter. Avoid explicit declaration of Events API (coming in via the JDBC events starter). Using the Insight starter (combining both actuators and observability).